### PR TITLE
Fixed relation protected keyword issue, setDatabaseConnection, pulling back SQL, Multiple Join issue

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -78,6 +78,18 @@ abstract class ActiveRecord extends Base implements JsonSerializable
      */
     protected array $sqlExpressions = [];
 
+	/**
+	 * @var string SQL that is built to be used by execute()
+	 */
+	protected string $built_sql = '';
+
+	/**
+	 * Captures all the joins that are made
+	 *
+	 * @var Expressions|null
+	 */
+	protected ?Expressions $join = null;
+
     /**
      * Database connection
      *
@@ -361,6 +373,20 @@ abstract class ActiveRecord extends Base implements JsonSerializable
         return $this->databaseConnection;
     }
 
+	/**
+	 * set the database connection.
+	 * @param DatabaseInterface|mysqli|PDO $databaseConnection
+	 * @return void
+	 */
+	public function setDatabaseConnection($databaseConnection): void
+	{
+		if (($databaseConnection instanceof DatabaseInterface) === true) {
+            $this->databaseConnection = $databaseConnection;
+        } else {
+			$this->transformAndPersistConnection($databaseConnection);
+		}
+	}
+
     /**
      * function to find one record and assign in to current object.
      * @param int|string $id If call this function using this param, will find record by using this id. If not set, just find the first record in database.
@@ -535,6 +561,12 @@ abstract class ActiveRecord extends Base implements JsonSerializable
      */
     protected function &getRelation(string $name)
     {
+
+		// can't set the name of a relation to a protected keyword
+		if(in_array($name, ['select', 'from', 'join', 'where', 'group', 'having', 'order', 'limit', 'offset'], true) === true) {
+			throw new Exception($name. ' is a protected keyword and cannot be used as a relation name');
+		}
+
         $relation = $this->relations[$name];
         if (is_array($relation) === true) {
             // ActiveRecordData::BELONGS_TO etc
@@ -604,8 +636,19 @@ abstract class ActiveRecord extends Base implements JsonSerializable
         }
         //this code to debug info.
         //echo 'SQL: ', implode(' ', $sql_statements), "\n", "PARAMS: ", implode(', ', $this->params), "\n";
-        return implode(' ', $sql_statements);
+		$this->built_sql = implode(' ', $sql_statements);
+        return $this->built_sql;
     }
+
+	/**
+	 * Gets the built SQL after buildSql has been called
+	 *
+	 * @return string
+	 */
+	public function getBuiltSql(): string
+	{
+		return $this->built_sql;
+	}
     /**
      * make wrap when build the SQL expressions of WHERE.
      * @param string $op If give this param will build one WrapExpressions include the stored expressions add into WHERE. Otherwise will stored the expressions into array.

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -78,17 +78,17 @@ abstract class ActiveRecord extends Base implements JsonSerializable
      */
     protected array $sqlExpressions = [];
 
-	/**
-	 * @var string SQL that is built to be used by execute()
-	 */
-	protected string $built_sql = '';
+    /**
+     * @var string SQL that is built to be used by execute()
+     */
+    protected string $built_sql = '';
 
-	/**
-	 * Captures all the joins that are made
-	 *
-	 * @var Expressions|null
-	 */
-	protected ?Expressions $join = null;
+    /**
+     * Captures all the joins that are made
+     *
+     * @var Expressions|null
+     */
+    protected ?Expressions $join = null;
 
     /**
      * Database connection
@@ -373,19 +373,19 @@ abstract class ActiveRecord extends Base implements JsonSerializable
         return $this->databaseConnection;
     }
 
-	/**
-	 * set the database connection.
-	 * @param DatabaseInterface|mysqli|PDO $databaseConnection
-	 * @return void
-	 */
-	public function setDatabaseConnection($databaseConnection): void
-	{
-		if (($databaseConnection instanceof DatabaseInterface) === true) {
+    /**
+     * set the database connection.
+     * @param DatabaseInterface|mysqli|PDO $databaseConnection
+     * @return void
+     */
+    public function setDatabaseConnection($databaseConnection): void
+    {
+        if (($databaseConnection instanceof DatabaseInterface) === true) {
             $this->databaseConnection = $databaseConnection;
         } else {
-			$this->transformAndPersistConnection($databaseConnection);
-		}
-	}
+            $this->transformAndPersistConnection($databaseConnection);
+        }
+    }
 
     /**
      * function to find one record and assign in to current object.
@@ -500,7 +500,7 @@ abstract class ActiveRecord extends Base implements JsonSerializable
             }
         }
 
-		return $record;
+        return $record;
     }
 
     /**
@@ -562,10 +562,10 @@ abstract class ActiveRecord extends Base implements JsonSerializable
     protected function &getRelation(string $name)
     {
 
-		// can't set the name of a relation to a protected keyword
-		if(in_array($name, ['select', 'from', 'join', 'where', 'group', 'having', 'order', 'limit', 'offset'], true) === true) {
-			throw new Exception($name. ' is a protected keyword and cannot be used as a relation name');
-		}
+        // can't set the name of a relation to a protected keyword
+        if (in_array($name, ['select', 'from', 'join', 'where', 'group', 'having', 'order', 'limit', 'offset'], true) === true) {
+            throw new Exception($name . ' is a protected keyword and cannot be used as a relation name');
+        }
 
         $relation = $this->relations[$name];
         if (is_array($relation) === true) {
@@ -636,19 +636,19 @@ abstract class ActiveRecord extends Base implements JsonSerializable
         }
         //this code to debug info.
         //echo 'SQL: ', implode(' ', $sql_statements), "\n", "PARAMS: ", implode(', ', $this->params), "\n";
-		$this->built_sql = implode(' ', $sql_statements);
+        $this->built_sql = implode(' ', $sql_statements);
         return $this->built_sql;
     }
 
-	/**
-	 * Gets the built SQL after buildSql has been called
-	 *
-	 * @return string
-	 */
-	public function getBuiltSql(): string
-	{
-		return $this->built_sql;
-	}
+    /**
+     * Gets the built SQL after buildSql has been called
+     *
+     * @return string
+     */
+    public function getBuiltSql(): string
+    {
+        return $this->built_sql;
+    }
     /**
      * make wrap when build the SQL expressions of WHERE.
      * @param string $op If give this param will build one WrapExpressions include the stored expressions add into WHERE. Otherwise will stored the expressions into array.

--- a/tests/ActiveRecordPdoIntegrationTest.php
+++ b/tests/ActiveRecordPdoIntegrationTest.php
@@ -492,61 +492,62 @@ class ActiveRecordPdoIntegrationTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($users[0]->isHydrated());
     }
 
-	public function testRelationsCascadingSave()
+    public function testRelationsCascadingSave()
     {
         $user = new User(new PDO('sqlite:test.db'));
         $user->name = 'demo';
         $user->password = md5('demo');
         $user->insert();
 
-		$user->name = 'bobby';
-		$user->contact->user_id = $user->id;
-		$user->contact->email = 'test@amail.com';
-		$user->contact->address = 'test address';
-		$user->save();
+        $user->name = 'bobby';
+        $user->contact->user_id = $user->id;
+        $user->contact->email = 'test@amail.com';
+        $user->contact->address = 'test address';
+        $user->save();
 
-		$this->assertEquals($user->id, $user->contact->user_id);
-		$this->assertFalse($user->contact->isDirty());
-		$this->assertGreaterThan(0, $user->contact->id);
-		$this->assertFalse($user->isDirty());
+        $this->assertEquals($user->id, $user->contact->user_id);
+        $this->assertFalse($user->contact->isDirty());
+        $this->assertGreaterThan(0, $user->contact->id);
+        $this->assertFalse($user->isDirty());
     }
 
-	public function testSetDatabaseConnection()
-	{
-		$user = new User();
-		$user->setDatabaseConnection(new PDO('sqlite:test.db'));
-		$user->name = 'bob';
-		$user->password = 'pass';
-		$user->save();
+    public function testSetDatabaseConnection()
+    {
+        $user = new User();
+        $user->setDatabaseConnection(new PDO('sqlite:test.db'));
+        $user->name = 'bob';
+        $user->password = 'pass';
+        $user->save();
 
-		$this->assertGreaterThan(0, $user->id);
-	}
+        $this->assertGreaterThan(0, $user->id);
+    }
 
-	public function testSetDatabaseConnectionWithAdapter()
-	{
-		$user = new User();
-		$user->setDatabaseConnection(new PdoAdapter(new PDO('sqlite:test.db')));
-		$user->name = 'bob';
-		$user->password = 'pass';
-		$user->save();
+    public function testSetDatabaseConnectionWithAdapter()
+    {
+        $user = new User();
+        $user->setDatabaseConnection(new PdoAdapter(new PDO('sqlite:test.db')));
+        $user->name = 'bob';
+        $user->password = 'pass';
+        $user->save();
 
-		$this->assertGreaterThan(0, $user->id);
-	}
+        $this->assertGreaterThan(0, $user->id);
+    }
 
-	public function testRelationWithProtectedKeyword() {
-		$user = new User(new PDO('sqlite:test.db'));
-		$user->name = 'demo';
-		$user->password = md5('demo');
-		$user->insert();
+    public function testRelationWithProtectedKeyword()
+    {
+        $user = new User(new PDO('sqlite:test.db'));
+        $user->name = 'demo';
+        $user->password = md5('demo');
+        $user->insert();
 
-		$contact = new class(new PDO('sqlite:test.db')) extends ActiveRecord {
-			protected array $relations = [
-				'group' => [self::HAS_ONE, User::class, 'user_id']
-			];
-		};
+        $contact = new class (new PDO('sqlite:test.db')) extends ActiveRecord {
+            protected array $relations = [
+                'group' => [self::HAS_ONE, User::class, 'user_id']
+            ];
+        };
 
-		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('group is a protected keyword and cannot be used as a relation name');
-		$contact->group->id;
-	}
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('group is a protected keyword and cannot be used as a relation name');
+        $contact->group->id;
+    }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -117,4 +117,27 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('John', $record->name);
         $this->assertEquals(['name' => 'John'], $record->getData());
     }
+
+	public function testIsset()
+	{
+		$record = new class (null, 'test_table') extends ActiveRecord {
+		};
+		$record->name = 'John';
+		$this->assertTrue(isset($record->name));
+		$this->assertFalse(isset($record->email));
+	}
+
+	public function testMultipleJoins()
+    {
+        $record = new class (null, 'test_table') extends ActiveRecord {
+			public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+			{
+				return $this;
+			}
+        };
+        $record->join('table1', 'table1.some_id = test_table.id');
+		$record->join('table2', 'table2.some_id = table1.id');
+        $result = $record->find()->getBuiltSql();
+		$this->assertEquals('SELECT test_table.* FROM test_table  LEFT JOIN table1 ON table1.some_id = test_table.id LEFT JOIN table2 ON table2.some_id = table1.id       LIMIT 1  ', $result);
+    }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -118,26 +118,26 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['name' => 'John'], $record->getData());
     }
 
-	public function testIsset()
-	{
-		$record = new class (null, 'test_table') extends ActiveRecord {
-		};
-		$record->name = 'John';
-		$this->assertTrue(isset($record->name));
-		$this->assertFalse(isset($record->email));
-	}
-
-	public function testMultipleJoins()
+    public function testIsset()
     {
         $record = new class (null, 'test_table') extends ActiveRecord {
-			public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
-			{
-				return $this;
-			}
+        };
+        $record->name = 'John';
+        $this->assertTrue(isset($record->name));
+        $this->assertFalse(isset($record->email));
+    }
+
+    public function testMultipleJoins()
+    {
+        $record = new class (null, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
         };
         $record->join('table1', 'table1.some_id = test_table.id');
-		$record->join('table2', 'table2.some_id = table1.id');
+        $record->join('table2', 'table2.some_id = table1.id');
         $result = $record->find()->getBuiltSql();
-		$this->assertEquals('SELECT test_table.* FROM test_table  LEFT JOIN table1 ON table1.some_id = test_table.id LEFT JOIN table2 ON table2.some_id = table1.id       LIMIT 1  ', $result);
+        $this->assertEquals('SELECT test_table.* FROM test_table  LEFT JOIN table1 ON table1.some_id = test_table.id LEFT JOIN table2 ON table2.some_id = table1.id       LIMIT 1  ', $result);
     }
 }


### PR DESCRIPTION
- There was an issue if you named a relation something like 'group' it would throw a weird non-helpful error that would make you triage the bug for a while.
- You can now set the database connection (for instance in a long running cron and you need to refresh the connection)
- You can now evaluate the the SQL that was compiled
- There was a bug introduced with `__isset()` being created where the `$this->join` property was being dynamically set.