### PR TITLE
fix: beforeUpdate & beforeSave is not working

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -473,11 +473,13 @@ abstract class ActiveRecord extends Base implements JsonSerializable
         if (count($this->dirty) === 0) {
             return $this->resetQueryData();
         }
+
+        $this->processEvent([ 'beforeUpdate', 'beforeSave' ], [ $this ]);
+
         foreach ($this->dirty as $field => $value) {
             $this->addCondition($field, '=', $value, ',', 'set');
         }
 
-        $this->processEvent([ 'beforeUpdate', 'beforeSave' ], [ $this ]);
         $this->execute($this->eq($this->primaryKey, $this->{$this->primaryKey})->buildSql(['update', 'set', 'where']), $this->params);
 
         $this->processEvent([ 'afterUpdate', 'afterSave' ], [ $this ]);


### PR DESCRIPTION
The beforeUpdate & beforeSave event should be processed before the `$this->dirty` array is used to build the update sql, otherwise the data change described in beforeUpdate & beforeSave event will not be included in the sql.

refer to the #12 issue.