### PR TITLE
Fix for table prefix being supplied.

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -716,8 +716,11 @@ abstract class ActiveRecord extends Base implements JsonSerializable
             $value = $this->filterParam($value);
         }
         $name = strtolower($name);
+
+		// skip adding the `table.` prefix if it's already there or a function is being supplied.
+		$skip_table_prefix = (strpos($field, '.') !== false || strpos($field, '(') !== false);
         $expressions = new Expressions([
-            'source' => ('where' === $name ? $this->table . '.' : '') . $field,
+            'source' => ('where' === $name && $skip_table_prefix === false ? $this->table . '.' : '') . $field,
             'operator' => $operator,
             'target' => (
                 is_array($value)


### PR DESCRIPTION
This fix cover 2 areas when supplying your own table prefixes in WHERE conditions:
1. When you supply the prefix yourself `->eq('some_other_table.field_name', $some_value);`
2. When you supply a function in the where statement `->eq('json_extract(json_data, $.info)', $some_value);`