### PR TITLE
Windows and escape fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FlightPHP Active Record 
-[![Latest Stable Version](http://poser.pugx.org/flightphp/active-record/v)](https://packagist.org/packages/flightphp/active-record)
+[![Latest Stable Version](https://poser.pugx.org/flightphp/active-record/v)](https://packagist.org/packages/flightphp/active-record)
 [![License](https://poser.pugx.org/flightphp/active-record/license)](https://packagist.org/packages/flightphp/active-record)
-[![PHP Version Require](http://poser.pugx.org/flightphp/active-record/require/php)](https://packagist.org/packages/flightphp/active-record)
-[![Dependencies](http://poser.pugx.org/flightphp/active-record/dependents)](https://packagist.org/packages/flightphp/active-record)
+[![PHP Version Require](https://poser.pugx.org/flightphp/active-record/require/php)](https://packagist.org/packages/flightphp/active-record)
+[![Dependencies](https://poser.pugx.org/flightphp/active-record/dependents)](https://packagist.org/packages/flightphp/active-record)
 
 An active record is mapping a database entity to a PHP object. Spoken plainly, if you have a users table in your database, you can "translate" a row in that table to a `User` class and a `$user` object in your codebase. See [basic example](#basic-example).
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.8",
         "rregeer/phpunit-coverage-check": "^0.3.1",
-        "flightphp/runway": "^0.2"
+        "flightphp/runway": "^0.2.4 || ^1.0"
     },
 	"autoload": {
 		"psr-4": {"flight\\": "src/"}
@@ -35,6 +35,6 @@
 		"test": "phpunit",
 		"test-coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=coverage --coverage-clover=clover.xml && vendor/bin/coverage-check clover.xml 100",
 		"beautify": "phpcbf --standard=phpcs.xml",
-		"phpcs": "phpcs --standard=phpcs.xml"
-	 }
+		"phpcs": "phpcs -n --standard=phpcs.xml"
+	}
 }

--- a/src/database/pdo/PdoAdapter.php
+++ b/src/database/pdo/PdoAdapter.php
@@ -42,4 +42,14 @@ class PdoAdapter implements DatabaseInterface
     {
         return $this->pdo->lastInsertId();
     }
+
+    /**
+     * Returns a PDO connection to the database.
+     *
+     * @return PDO The PDO connection instance.
+     */
+    public function getConnection(): PDO
+    {
+        return $this->pdo;
+    }
 }

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -13,6 +13,7 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
     public function testMagicSet()
     {
         $pdo_mock = $this->createStub(PDO::class);
+        $pdo_mock->method('getAttribute')->willReturn('generic');
         $record = new class ($pdo_mock) extends ActiveRecord {
             public function getDirty()
             {
@@ -28,6 +29,7 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
     public function testExecutePdoError()
     {
         $pdo_mock = $this->createStub(PDO::class);
+        $pdo_mock->method('getAttribute')->willReturn('generic');
         $pdo_mock->method('prepare')->willReturn(false);
         $pdo_mock->method('errorInfo')->willReturn(['HY000', 1, 'test']);
         $record = new class ($pdo_mock) extends ActiveRecord {
@@ -42,6 +44,7 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
         $statement_mock = $this->createStub(PDOStatement::class);
         $pdo_mock = $this->createStub(PDO::class);
         $pdo_mock->method('prepare')->willReturn($statement_mock);
+        $pdo_mock->method('getAttribute')->willReturn('generic');
         $statement_mock->method('execute')->willReturn(false);
         $statement_mock->method('errorInfo')->willReturn(['HY000', 1, 'test_statement']);
         $record = new class ($pdo_mock) extends ActiveRecord {
@@ -54,6 +57,7 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
     public function testUnsetSqlExpressions()
     {
         $pdo_mock = $this->createStub(PDO::class);
+        $pdo_mock->method('getAttribute')->willReturn('generic');
         $record = new class ($pdo_mock) extends ActiveRecord {
         };
         $record->where = '1';
@@ -64,6 +68,7 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
     public function testCustomData()
     {
         $pdo_mock = $this->createStub(PDO::class);
+        $pdo_mock->method('getAttribute')->willReturn('generic');
         $record = new class ($pdo_mock) extends ActiveRecord {
         };
         $record->setCustomData('test', 'something');
@@ -73,6 +78,7 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
     public function testCustomDataUnset()
     {
         $pdo_mock = $this->createStub(PDO::class);
+        $pdo_mock->method('getAttribute')->willReturn('generic');
         $record = new class ($pdo_mock) extends ActiveRecord {
         };
         $record->setCustomData('test', 'something');

--- a/tests/commands/RecordCommandTest.php
+++ b/tests/commands/RecordCommandTest.php
@@ -11,11 +11,16 @@ use PHPUnit\Framework\TestCase;
 
 class RecordCommandTest extends TestCase
 {
-    protected static $in = __DIR__ . '/input.test';
-    protected static $ou = __DIR__ . '/output.test';
+    protected static $in = '';
+    protected static $ou = '';
 
     public function setUp(): void
     {
+        static::$in = __DIR__ . '/input.test' . uniqid('', true);
+        static::$ou = __DIR__ . '/output.test' . uniqid('', true);
+        if (!file_exists(__DIR__ . '/records/')) {
+            mkdir(__DIR__ . '/records/');
+        }
         file_put_contents(static::$in, '', LOCK_EX);
         file_put_contents(static::$ou, '', LOCK_EX);
 
@@ -34,17 +39,14 @@ class RecordCommandTest extends TestCase
             unlink(static::$ou);
         }
 
-        if (file_exists(__DIR__ . '/records/UserRecord.php')) {
-            unlink(__DIR__ . '/records/UserRecord.php');
+        // find any files in records folder and delete them
+        foreach (glob(__DIR__ . '/records/*') as $file) {
+            unlink($file);
         }
 
-        if (file_exists(__DIR__ . '/records/StatusRecord.php')) {
-            unlink(__DIR__ . '/records/StatusRecord.php');
-        }
-
-        if (file_exists(__DIR__ . '/records/')) {
-            rmdir(__DIR__ . '/records/');
-        }
+        // if (file_exists(__DIR__ . '/records/')) {
+        //     rmdir(__DIR__ . '/records/');
+        // }
     }
 
     protected function newApp(string $in = '')
@@ -85,8 +87,7 @@ class RecordCommandTest extends TestCase
 
     public function testRecordAlreadyExists()
     {
-        mkdir(__DIR__ . '/records/');
-        file_put_contents(__DIR__ . '/records/UserRecord.php', '<?php class UserRecord {}');
+        file_put_contents(__DIR__ . '/records/CompanyRecord.php', '<?php class CompanyRecord {}');
         $app = $this->newApp();
         $app->add(new RecordCommand([
             'app_root' => 'tests/commands/',
@@ -95,15 +96,14 @@ class RecordCommandTest extends TestCase
                 'file_path' => ':memory:'
             ]
         ]));
-        $app->handle(['runway', 'make:record', 'users']);
+        $app->handle(['runway', 'make:record', 'company']);
 
-        $this->assertStringContainsString('UserRecord already exists.', file_get_contents(static::$ou));
+        $this->assertStringContainsString('CompanyRecord already exists.', file_get_contents(static::$ou));
     }
 
     public function testRecordAlreadyExistsMysql()
     {
-        mkdir(__DIR__ . '/records/');
-        file_put_contents(__DIR__ . '/records/UserRecord.php', '<?php class UserRecord {}');
+        file_put_contents(__DIR__ . '/records/TestRecord.php', '<?php class TestRecord {}');
         $commands = <<<TEXT
             mysql
             localhost
@@ -117,15 +117,14 @@ class RecordCommandTest extends TestCase
         $app->add(new RecordCommand([
             'app_root' => 'tests/commands/'
         ]));
-        $app->handle(['runway', 'make:record', 'users']);
+        $app->handle(['runway', 'make:record', 'test']);
 
-        $this->assertStringContainsString('UserRecord already exists.', file_get_contents(static::$ou));
+        $this->assertStringContainsString('TestRecord already exists.', file_get_contents(static::$ou));
     }
 
     public function testRecordAlreadyExistsPgsql()
     {
-        mkdir(__DIR__ . '/records/');
-        file_put_contents(__DIR__ . '/records/UserRecord.php', '<?php class UserRecord {}');
+        file_put_contents(__DIR__ . '/records/SomethingRecord.php', '<?php class SomethingRecord {}');
         $commands = <<<TEXT
             mysql
             localhost
@@ -139,9 +138,9 @@ class RecordCommandTest extends TestCase
         $app->add(new RecordCommand([
             'app_root' => 'tests/commands/'
         ]));
-        $app->handle(['runway', 'make:record', 'users']);
+        $app->handle(['runway', 'make:record', 'somethings']);
 
-        $this->assertStringContainsString('UserRecord already exists.', file_get_contents(static::$ou));
+        $this->assertStringContainsString('SomethingRecord already exists.', file_get_contents(static::$ou));
     }
 
     public function testSqliteCreation()
@@ -177,10 +176,10 @@ class RecordCommandTest extends TestCase
             }
         };
         $app->add($RecordCommand);
-        $app->handle(['runway', 'make:record', 'users']);
+        $app->handle(['runway', 'make:record', 'guys']);
 
-        $this->assertFileExists(__DIR__ . '/records/UserRecord.php');
-        $file_contents = file_get_contents(__DIR__ . '/records/UserRecord.php');
+        $this->assertFileExists(__DIR__ . '/records/GuyRecord.php');
+        $file_contents = file_get_contents(__DIR__ . '/records/GuyRecord.php');
         $this->assertStringContainsString('@property int $id', $file_contents);
         $this->assertStringContainsString('@property string $name', $file_contents);
         $this->assertStringContainsString('@property float $price', $file_contents);
@@ -220,10 +219,10 @@ class RecordCommandTest extends TestCase
             }
         };
         $app->add($RecordCommand);
-        $app->handle(['runway', 'make:record', 'users']);
+        $app->handle(['runway', 'make:record', 'yikes']);
 
-        $this->assertFileExists(__DIR__ . '/records/UserRecord.php');
-        $file_contents = file_get_contents(__DIR__ . '/records/UserRecord.php');
+        $this->assertFileExists(__DIR__ . '/records/YikeRecord.php');
+        $file_contents = file_get_contents(__DIR__ . '/records/YikeRecord.php');
         $this->assertStringContainsString('@property int $id', $file_contents);
         $this->assertStringContainsString('@property string $name', $file_contents);
         $this->assertStringContainsString('@property float $price', $file_contents);
@@ -263,10 +262,10 @@ class RecordCommandTest extends TestCase
             }
         };
         $app->add($RecordCommand);
-        $app->handle(['runway', 'make:record', 'users']);
+        $app->handle(['runway', 'make:record', 'boys']);
 
-        $this->assertFileExists(__DIR__ . '/records/UserRecord.php');
-        $file_contents = file_get_contents(__DIR__ . '/records/UserRecord.php');
+        $this->assertFileExists(__DIR__ . '/records/BoyRecord.php');
+        $file_contents = file_get_contents(__DIR__ . '/records/BoyRecord.php');
         $this->assertStringContainsString('@property int $id', $file_contents);
         $this->assertStringContainsString('@property string $name', $file_contents);
         $this->assertStringContainsString('@property float $price', $file_contents);


### PR DESCRIPTION
There were some issues resolved in this branch:
- Windows was having some issues running local unit tests (again thanks `unlink()` bug in windows)
- Table names and column names were not escaped by database engine. This adds either double quotes or backticks depending on the engine. This should bypass any issues with names of tables starting with numbers (SQLite) or columns with spaces.