### PR TITLE
Fix insert() and update() ignoring typed public properties

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -396,6 +396,56 @@ abstract class ActiveRecord extends Base implements JsonSerializable
     }
 
     /**
+     * Syncs declared public properties into $dirty for insert/update.
+     *
+     * Direct assignment to typed public properties bypasses __set(), so
+     * $dirty stays empty. This method detects initialized declared properties
+     * and copies them into $dirty so insert() and update() pick them up.
+     *
+     * @param bool $onlyChanged When true, only sync properties whose value
+     *                          differs from $data (for update). When false,
+     *                          sync all initialized properties (for insert).
+     */
+    protected function syncDirtyFromProperties(bool $onlyChanged = false): void
+    {
+        $ref = new \ReflectionClass($this);
+        $parentRef = new \ReflectionClass(self::class);
+
+        foreach ($ref->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
+            if ($prop->isStatic()) {
+                continue;
+            }
+
+            // Skip properties that exist on ActiveRecord (even if redeclared by subclass)
+            if ($parentRef->hasProperty($prop->getName())) {
+                continue;
+            }
+
+            $name = $prop->getName();
+
+            // Skip the primary key
+            if ($name === $this->primaryKey) {
+                continue;
+            }
+
+            if (!$prop->isInitialized($this) || array_key_exists($name, $this->dirty)) {
+                continue;
+            }
+
+            $currentValue = $this->{$name};
+
+            if ($onlyChanged) {
+                $storedValue = $this->data[$name] ?? null;
+                if ($currentValue != $storedValue) {
+                    $this->dirty[$name] = $currentValue;
+                }
+            } else {
+                $this->dirty[$name] = $currentValue;
+            }
+        }
+    }
+
+    /**
      * get the database connection.
      * @return DatabaseInterface
      */
@@ -509,6 +559,10 @@ abstract class ActiveRecord extends Base implements JsonSerializable
         // execute this before anything else, this could change $this->dirty
         $this->processEvent(['beforeInsert', 'beforeSave'], [$this]);
 
+        // Sync typed public properties into dirty — direct assignment to
+        // declared properties bypasses __set() and leaves dirty empty.
+        $this->syncDirtyFromProperties(false);
+
         if (count($this->dirty) === 0) {
             return $this->resetQueryData();
         }
@@ -544,6 +598,9 @@ abstract class ActiveRecord extends Base implements JsonSerializable
     public function update(): ActiveRecord
     {
         $this->processEvent(['beforeUpdate', 'beforeSave'], [$this]);
+
+        // Sync typed public properties that changed since the last find/sync.
+        $this->syncDirtyFromProperties(true);
 
         foreach ($this->dirty as $field => $value) {
             $this->addCondition($field, '=', $value, ',', 'set');

--- a/tests/TypedPropertyTest.php
+++ b/tests/TypedPropertyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace flight\tests;
+
+use flight\tests\classes\TypedUser;
+use PDO;
+
+/**
+ * Tests that insert() and update() correctly handle typed public properties
+ * when values are assigned directly (bypassing __set / dirty tracking).
+ */
+class TypedPropertyTest extends \PHPUnit\Framework\TestCase
+{
+    protected PDO $pdo;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/classes/TypedUser.php';
+        @unlink('test_typed.db');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        @unlink('test_typed.db');
+    }
+
+    public function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite:test_typed.db');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec("CREATE TABLE IF NOT EXISTS user (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            password TEXT,
+            created_dt TEXT
+        )");
+    }
+
+    public function tearDown(): void
+    {
+        $this->pdo->exec("DROP TABLE IF EXISTS user");
+    }
+
+    public function testInsertWithTypedProperties(): void
+    {
+        $user = new TypedUser($this->pdo);
+        $user->name = 'charlie';
+        $user->password = 'hash3';
+        $user->insert();
+
+        // Verify persisted via raw query (avoids isHydrated/lastInsertId dependencies)
+        $row = $this->pdo->query("SELECT * FROM user WHERE name = 'charlie'")->fetch(PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row, 'insert should persist when properties are set directly');
+        $this->assertSame('charlie', $row['name']);
+        $this->assertSame('hash3', $row['password']);
+    }
+
+    public function testUpdateWithTypedProperties(): void
+    {
+        $this->pdo->exec("INSERT INTO user (name, password) VALUES ('eve', 'hash5')");
+
+        // Use the untyped User to find (avoids isHydrated dependency)
+        // Then update via typed property assignment
+        $user = new TypedUser($this->pdo);
+        $user->dirty(['name' => 'eve']); // simulate populating data
+        $user->eq('name', 'eve')->find();
+
+        // Direct property assignment should be detected by syncDirtyFromProperties
+        $user->name = 'eve_updated';
+        $user->save();
+
+        $row = $this->pdo->query("SELECT * FROM user WHERE id = 1")->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('eve_updated', $row['name'], 'update should persist changed typed property');
+    }
+
+    public function testUpdateDoesNotTouchUnchangedFields(): void
+    {
+        $this->pdo->exec("INSERT INTO user (name, password) VALUES ('frank', 'hash6')");
+
+        $user = new TypedUser($this->pdo);
+        $user->eq('id', 1)->find();
+        $user->name = 'frank_updated';
+        $user->save();
+
+        $row = $this->pdo->query("SELECT * FROM user WHERE id = 1")->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('frank_updated', $row['name']);
+        $this->assertSame('hash6', $row['password'], 'unchanged field should not be modified');
+    }
+}

--- a/tests/classes/TypedUser.php
+++ b/tests/classes/TypedUser.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace flight\tests\classes;
+
+use flight\ActiveRecord;
+
+/**
+ * Test subclass with typed public properties.
+ * Used to verify ActiveRecord works correctly when subclasses
+ * declare typed properties instead of using dynamic properties.
+ */
+class TypedUser extends ActiveRecord
+{
+    public int $id;
+    public string $name;
+    public string $password;
+    public ?string $created_dt = null;
+
+    public function __construct($databaseConnection = null, array $config = [])
+    {
+        parent::__construct($databaseConnection, 'user', $config);
+    }
+}


### PR DESCRIPTION
I created a subclass with typed properties and attempted an insert:

```php
class User extends \flight\ActiveRecord {
    public function __construct($pdo = null) {
        parent::__construct($pdo, 'users');
    }
    public int $id;
    public string $name;
}

$user = new User($pdo);
$user->name = 'John';
$user->insert();
```

I expected a new row to be inserted into the database.

Instead, nothing is inserted — the method returns early because `$dirty` is empty.

The same issue affects `update()` after `find()`:

```php
$user = new User($pdo);
$user->eq('id', 1)->find();
$user->name = 'Updated';
$user->save();
```

I expected the name to be updated to `"Updated"`. Instead, no update is issued.

Subclasses without typed properties are not affected.

Tests included. All existing tests continue to pass.