### PR TITLE
Harden SQL identifier escaping and raw SQL APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,201 @@
+# AGENTS.md — FlightPHP Active Record
+
+Guidance for AI agents and contributors working in this repository.
+
+This package follows the same philosophy as [flightphp/core](https://github.com/flightphp/core). Ideologies below are adapted from core’s project guidelines and applied where they fit an ORM plugin (not the framework kernel).
+
+## Overview
+
+**flightphp/active-record** is a micro Active Record library: map a database row to a PHP object with chainable queries, relations, events, and PDO/mysqli adapters.
+
+- **Package:** `flightphp/active-record` (Packagist)
+- **License:** MIT
+- **PHP:** `>=7.4` (PHP 8+ supported; do not require 8-only syntax)
+- **Runtime dependencies:** none (only PHP itself)
+- **Namespace:** `flight\` (PSR-4 → `src/`)
+- **Docs:** https://docs.flightphp.com/en/v3/awesome-plugins/active-record
+- **README:** [README.md](./README.md) (short intro; full API is in the docs)
+
+Works standalone or with [Flight PHP](https://docs.flightphp.com). It does **not** require Flight core at runtime.
+
+## Project guidelines
+
+These are the Flight ecosystem rules that apply to this repo. Prefer them over inventing framework-heavy patterns.
+
+1. **PHP 7.4 must stay supported.** PHP 8+ is fine, but avoid PHP 8-only features (union types, constructor property promotion, `match`, named arguments in library code, mixed union returns, etc.) unless the project explicitly raises the minimum version.
+
+2. **Stay dependency-free at runtime.** Do not add Composer runtime dependencies, polyfills, or interface-only packages “for cleanliness.” Dev tools (PHPUnit, PHPCS, runway, coverage-check) are fine under `require-dev`.
+
+3. **Simple and fast.** Flight projects prioritize performance and a small surface area. Prefer fewer allocations, fewer queries (e.g. eager load over N+1), and straightforward SQL building over clever abstractions.
+
+4. **Do not bloat the library.** New capability should earn its place. Prefer a small, composable API over a kitchen-sink ORM. If something is large or optional (CLI scaffolding, etc.), keep it in a clear corner (`commands/`, runway) rather than growing `ActiveRecord` forever.
+
+5. **This is not Eloquent / Doctrine / Laravel / Yii.** It is a micro Active Record: chainable conditions, light relations, events, and adapters. Do not smuggle in migrations, unit-of-work, attribute mapping layers, repositories-as-required-pattern, nested graph loaders, or other large-framework defaults unless there is a clear, minimal design that fits existing style.
+
+6. **New features must be documented and tested.** Public behavior needs tests (this repo enforces **100%** `src/` line coverage) and accurate docs/docblocks. User-facing API changes should remain valid against the [public docs](https://docs.flightphp.com/en/v3/awesome-plugins/active-record).
+
+7. **Simplicity over cleverness.** Magic (`__call`, `__get`, `__set`) already exists for the query/relation ergonomics—do not add more layers of indirection without a strong reason. Prefer readable condition building and explicit relation config.
+
+8. **Extensibility without core bloat.** Prefer extension points users already have: subclass methods (events), `$relations`, `DatabaseInterface` adapters, `setCustomData`, chainable query methods. Avoid hard-wiring Flight framework services into the library.
+
+## Repository layout
+
+```
+src/
+  ActiveRecord.php          # Main abstract model — CRUD, queries, relations, eager load, events
+  ActiveRecordData.php      # OPERATORS, SQL_PARTS, DEFAULT_SQL_EXPRESSIONS, EVENTS
+  Base.php                  # Attribute bag ($data) with magic __get/__set
+  Expressions.php           # SQL fragment value object
+  WrapExpressions.php       # Parenthesized expression groups (OR/AND wraps)
+  database/
+    DatabaseInterface.php
+    DatabaseStatementInterface.php
+    pdo/                    # PdoAdapter, PdoStatementAdapter
+    mysqli/                 # MysqliAdapter, MysqliStatementAdapter
+  commands/
+    RecordCommand.php       # runway CLI: make:record (scaffold model from table schema)
+tests/
+  ActiveRecordTest.php
+  ActiveRecordPdoIntegrationTest.php
+  ActiveRecordMysqliTest.php
+  EagerLoadingTest.php
+  ExpressionsTest.php
+  WrapExpressionsTest.php
+  commands/RecordCommandTest.php
+  classes/                  # Fixtures: User, Contact, QueryCountingAdapter
+records/                    # Empty placeholder (app models go under runway app_root)
+```
+
+`coverage/` and `clover.xml` are generated (gitignored). Do not hand-edit them.
+
+## Core architecture (read before changing behavior)
+
+### Model lifecycle
+
+1. User subclasses `flight\ActiveRecord` and passes a DB connection + table name (or config) in the constructor.
+2. Raw `PDO` / `mysqli` is wrapped by `transformAndPersistConnection()` into a `DatabaseInterface` adapter.
+3. Property assignment goes through `__set` → `$data` + `$dirty` (unless the key is an SQL expression or relation).
+4. Query methods (`eq`, `like`, `orderBy`, …) are magic via `__call` → `ActiveRecordData::OPERATORS` / `SQL_PARTS`.
+5. `find` / `findAll` / `insert` / `update` / `delete` build SQL with named placeholders (`:phN` from `ActiveRecordData::PREFIX`), then execute through the adapter.
+6. Events (`beforeFind`, `afterInsert`, etc.) are optional protected methods on the subclass, listed in `ActiveRecordData::EVENTS`.
+
+### Relationships
+
+```php
+protected array $relations = [
+    'contacts' => [ self::HAS_MANY, Contact::class, 'user_id' ],
+    'contact'  => [ self::HAS_ONE,  Contact::class, 'user_id', [/* optional callbacks */] ],
+    'user'     => [ self::BELONGS_TO, User::class, 'user_id', [], 'back_ref_name' ],
+];
+```
+
+- `HAS_MANY` / `HAS_ONE`: third element is the **foreign key on the related table**.
+- `BELONGS_TO`: third element is the **local key** on the current model.
+- Optional 4th: callback map when resolving the relation (`eq`, `where`, `order`, …).
+- Optional 5th: back-reference property name.
+
+**Lazy load:** `$user->contacts` → `getRelation()`.  
+**Eager load:** `$user->with('contacts')->findAll()` → `loadEagerRelations()` batches with `IN (...)`.
+
+Eager-load limitations (do not “fix” without an intentional, minimal design):
+
+- No nested paths like `with(['contacts.addresses'])`
+- No closure constraints on `with()`
+- Unknown relation names throw `Exception`
+
+### Database adapters
+
+| Input type | Adapter |
+|------------|---------|
+| `PDO` | `flight\database\pdo\PdoAdapter` |
+| `mysqli` | `flight\database\mysqli\MysqliAdapter` |
+| `DatabaseInterface` | used as-is |
+
+mysqli converts named placeholders to `?`. Keep SQL/placeholder logic driver-agnostic when possible; put driver quirks in the adapter layer.
+
+### runway command
+
+`src/commands/RecordCommand.php` implements `make:record` for [flightphp/runway](https://docs.flightphp.com/awesome-plugins/runway). It introspects a table and writes a record class under `app_root` from `.runway-config.json`. Tests live under `tests/commands/`.
+
+## Development & testing
+
+```bash
+composer install
+
+composer test              # phpunit (random order, stop on failure)
+composer test-coverage     # HTML + clover; enforces 100% via coverage-check
+composer beautify          # phpcbf --standard=phpcs.xml
+composer phpcs             # phpcs -n --standard=phpcs.xml
+```
+
+**Coverage:** `src/` is expected to stay at **100%** line coverage. New branches need tests. Run `composer test-coverage` before considering work complete.
+
+- PHPUnit: `phpunit.xml` — suite = `tests/`, coverage = `src/`
+- Style: **PSR-12** via `phpcs.xml` on `src/` and `tests/` (this package uses PSR-12, not core’s PSR-1)
+- Prefer `declare(strict_types=1);`
+- Use **strict comparisons** (`===`, `!==`)
+
+### Testing conventions
+
+- Prefer **SQLite in-memory** (`sqlite::memory:`) for integration tests (`ext-pdo_sqlite` is required-dev).
+- Model fixtures: `tests/classes/` (`User`, `Contact`, …). Match real relation configs when testing relations/eager load.
+- Use `QueryCountingAdapter` to assert query counts (N+1 vs eager load).
+- Keep PDO vs mysqli differences in their own tests/adapters.
+- Fixtures are often `require_once`’d in `setUpBeforeClass`—follow that pattern unless you also add proper `autoload-dev`.
+
+## Coding standards (library-specific)
+
+Apply the project guidelines first; then these details when editing:
+
+1. **Chainable API.** Query builders and fluent mutators return `$this` / `self`.
+2. **Security.**
+   - Condition **values** (`eq`, `in`, `like`, …) are bound as parameters — safe for untrusted data.
+   - **Identifiers** go through `escapeIdentifier()` (delimiter-escaped per engine). Do not weaken this.
+   - `where()`, `having()`, `select()`, `order()`/`orderBy()`, `group()`, and `join()` **ON** accept raw SQL — never pass untrusted input. Prefer `eq()`/`in()`/… for filters and `orderByColumn()` for untrusted sort columns.
+   - Simple table names / `table alias` / `table AS alias` in `join()` are auto-quoted; complex join sources stay raw for BC.
+   - `copyFrom()`/`dirty()` keys become column names — only pass trusted keys.
+3. **Dirty tracking.** Inserts/updates persist `$dirty` only. Preserve that contract when changing assignment or `save()`.
+4. **Events.** Use `processEvent` and the names in `ActiveRecordData::EVENTS`. Keep hook signatures compatible with docs.
+5. **Public API is the contract.** Prefer additive changes. Keep README/docs examples working. New safe helpers (e.g. `orderByColumn`) are fine; do not change semantics of existing raw SQL methods for complex expressions.
+6. **Performance-conscious defaults.** Eager load exists to cut N+1; avoid designs that force per-row queries without an opt-in path.
+7. **No framework lock-in.** Do not require `Flight::` inside library code; examples in docs may show Flight registration for apps.
+
+## Documentation sources
+
+| Resource | Use for |
+|----------|---------|
+| [Active Record docs (v3)](https://docs.flightphp.com/en/v3/awesome-plugins/active-record) | Full public API, events, relations, eager loading, connections |
+| [README.md](./README.md) | Install + basic example |
+| [flightphp/core copilot instructions](https://github.com/flightphp/core/blob/master/.github/copilot-instructions.md) | Shared Flight ecosystem philosophy |
+| Packagist `flightphp/active-record` | Version / install metadata |
+
+User-visible behavior changes should stay aligned with the docs site when possible; at minimum keep in-repo comments and tests accurate.
+
+## Common tasks (agent playbook)
+
+| Goal | Where to look |
+|------|----------------|
+| Query operator / SQL part mapping | `ActiveRecordData.php`, `__call` in `ActiveRecord.php` |
+| find / findAll / insert / update / save / delete | `ActiveRecord.php` public methods |
+| Relation lazy load | `getRelation()` |
+| Eager load | `with()`, `loadEagerRelations()`, `assignEagerLoadedRelations()` |
+| Events | `processEvent()`, `ActiveRecordData::EVENTS` |
+| PDO/mysqli bugs | `src/database/**` + matching tests |
+| Scaffold CLI | `src/commands/RecordCommand.php` |
+| N+1 regression | `tests/EagerLoadingTest.php` + `QueryCountingAdapter` |
+
+## PR / contribution checklist
+
+- [ ] Change fits **project guidelines** (simple, fast, no bloat, PHP 7.4-safe, no new runtime deps)
+- [ ] `composer test` passes
+- [ ] `composer test-coverage` still meets 100%
+- [ ] `composer beautify` && `composer phpcs` clean
+- [ ] Public API covered by tests; docs/docblocks updated if behavior changed
+- [ ] No secrets or local `.runway-config.json` credentials committed (gitignored)
+
+## Out of scope / non-goals
+
+- Becoming a full ORM (migrations, schema builder, unit of work, nested eager-load graphs, polymorphic relations by default)
+- Runtime dependency on Flight core or other frameworks
+- Dropping PHP 7.4 support without an explicit project decision
+- “Just like Laravel Eloquent” feature parity

--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -27,6 +27,14 @@ use PDO;
  * Using magic function to implement more smarty functions.<br />
  * Can using chain method calls, to build concise and compactness program.<br />
  *
+ * Security notes:
+ * - Condition values via eq/like/in/etc. are bound as parameters (safe for untrusted values).
+ * - Table/column identifiers passed through escapeIdentifier() are quoted and delimiter-escaped.
+ * - where(), having(), select(), order()/orderBy(), group()/groupBy(), and join() ON clauses
+ *   accept raw SQL fragments. Do not pass untrusted input into those methods.
+ *   Prefer eq()/in()/… for filters, and orderByColumn() when the sort column may be user-supplied.
+ * - copyFrom()/dirty() treat array keys as column names; only pass trusted keys (or a fixed allowlist).
+ *
  * @method self equal(string $field, mixed $value, string $operator = 'AND') Equal operator
  * @method self eq(string $field, mixed $value, string $operator = 'AND') Equal operator
  * @method self notEqual(string $field, mixed $value, string $operator = 'AND') Not Equal operator
@@ -50,16 +58,16 @@ use PDO;
  * @method self isNotNull(string $field, string $operator = 'AND') Is Not Null
  * @method self notNull(string $field, string $operator = 'AND') Not Null
  *
- * @method self select(string $field, [...$field2]) Select
+ * @method self select(string $field, [...$field2]) Select columns/expressions (raw SQL fragments — do not pass untrusted input)
  * @method self from(string $table) From
  * @method self join(string $table_to_join, string $join_condition) Join another table in the database
  * @method self set(string $field, mixed $value, [...$field2]) Set
- * @method self where(string $sql_conditions) Where
- * @method self group(string $field, [...$field2]) Group By
- * @method self groupBy(string $field, [...$field2]) Group By
- * @method self having(string $sql_conditions) Having
- * @method self order(string $field, [...$field2]) Order By
- * @method self orderBy(string $field, [...$field2]) Order By
+ * @method self where(string $sql_conditions) Raw WHERE SQL — do not interpolate untrusted input; use eq()/in()/etc. instead
+ * @method self group(string $field, [...$field2]) Group By (raw SQL fragments — do not pass untrusted input)
+ * @method self groupBy(string $field, [...$field2]) Group By (raw SQL fragments — do not pass untrusted input)
+ * @method self having(string $sql_conditions) Raw HAVING SQL — do not interpolate untrusted input
+ * @method self order(string $field, [...$field2]) Order By (raw SQL fragments — prefer orderByColumn() for untrusted sort fields)
+ * @method self orderBy(string $field, [...$field2]) Order By (raw SQL fragments — prefer orderByColumn() for untrusted sort fields)
  * @method self limit(int $limit) Limit
  * @method self offset(int $offset) Offset
  * @method self top(int $top) Top
@@ -215,6 +223,7 @@ abstract class ActiveRecord extends Base implements JsonSerializable
 
             $this->addCondition($field, $operator, $value, $and_or_or);
         } elseif (in_array($name, array_keys(ActiveRecordData::SQL_PARTS))) {
+            $args = $this->normalizeSqlPartArgs($name, $args);
             $this->{$name} = new Expressions([
                 'operator' => ActiveRecordData::SQL_PARTS[$name],
                 'target' => implode(', ', $args)
@@ -1145,8 +1154,14 @@ abstract class ActiveRecord extends Base implements JsonSerializable
     /**
      * helper function to add condition into JOIN.
      * create the SQL Expressions.
-     * @param string $table The join table name
-     * @param string $on The condition of ON
+     *
+     * Simple table names and `table alias` / `table AS alias` forms are identifier-escaped.
+     * Complex expressions (subqueries, already-quoted SQL) are left unchanged.
+     *
+     * The ON clause is raw SQL — do not interpolate untrusted input into $on.
+     *
+     * @param string $table The join table name (or "table alias" / "table AS alias")
+     * @param string $on The condition of ON (raw SQL fragment)
      * @param string $type The join type, like "LEFT", "INNER", "OUTER", "RIGHT"
      */
     public function join(string $table, string $on, string $type = 'LEFT')
@@ -1156,13 +1171,37 @@ abstract class ActiveRecord extends Base implements JsonSerializable
             'operator' => $type . ' JOIN',
             'target' => new Expressions(
                 [
-                    'source' => $table,
+                    'source' => $this->escapeJoinTable($table),
                     'operator' => 'ON',
                     'target' => $on
                 ]
             )
         ]);
         return $this;
+    }
+
+    /**
+     * ORDER BY a single column with ASC/DESC. Safe when the column name may be untrusted
+     * (e.g. from a request), unlike order()/orderBy() which accept raw SQL fragments.
+     *
+     * Only simple identifiers or table.column paths are allowed.
+     *
+     * @param string $column Column name or table.column
+     * @param string $direction ASC or DESC (case-insensitive)
+     * @return self
+     * @throws Exception If the column or direction is invalid
+     */
+    public function orderByColumn(string $column, string $direction = 'ASC'): self
+    {
+        $direction = strtoupper(trim($direction));
+        if ($direction !== 'ASC' && $direction !== 'DESC') {
+            throw new Exception('Invalid ORDER BY direction; use ASC or DESC');
+        }
+        if ($this->isSafeIdentifierPath($column) === false) {
+            throw new Exception('Invalid ORDER BY column identifier');
+        }
+
+        return $this->order($this->escapeIdentifierPath($column) . ' ' . $direction);
     }
 
     /**
@@ -1226,22 +1265,145 @@ abstract class ActiveRecord extends Base implements JsonSerializable
     /**
      * Escapes a database identifier (e.g., table or column name) to prevent SQL injection.
      *
+     * Delimiter characters inside the name are escaped per engine rules so a value such as
+     * id" OR 1=1 -- cannot break out of the quoted identifier.
+     *
      * @param string $name The database identifier to be escaped.
      * @return string The escaped database identifier.
      */
     public function escapeIdentifier(string $name)
     {
+        // Identifiers must not contain NUL bytes
+        $name = str_replace("\0", '', $name);
+
         switch ($this->databaseEngineType) {
             case 'sqlite':
             case 'pgsql':
-                return '"' . $name . '"';
+                return '"' . str_replace('"', '""', $name) . '"';
             case 'mysql':
-                return '`' . $name . '`';
+                return '`' . str_replace('`', '``', $name) . '`';
             case 'sqlsrv':
-                return '[' . $name . ']';
+                return '[' . str_replace(']', ']]', $name) . ']';
             default:
                 return $name;
         }
+    }
+
+    /**
+     * Escapes a dotted identifier path (e.g. table.column) by quoting each segment.
+     *
+     * @param string $path Identifier or table.column path (must already be a safe path)
+     * @return string
+     */
+    protected function escapeIdentifierPath(string $path): string
+    {
+        $parts = explode('.', $path);
+        $escaped = [];
+        foreach ($parts as $part) {
+            $escaped[] = $this->escapeIdentifier($part);
+        }
+        return implode('.', $escaped);
+    }
+
+    /**
+     * Whether a string is a safe identifier or table.column path (no SQL metacharacters).
+     *
+     * @param string $path
+     * @return bool
+     */
+    protected function isSafeIdentifierPath(string $path): bool
+    {
+        return (bool) preg_match('/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/', $path);
+    }
+
+    /**
+     * Escape join table when it is a simple table / alias form; leave complex SQL unchanged.
+     *
+     * @param string $table
+     * @return string
+     */
+    protected function escapeJoinTable(string $table): string
+    {
+        $table = trim($table);
+
+        // table AS alias
+        if (preg_match('/^([A-Za-z_][A-Za-z0-9_]*)\s+[Aa][Ss]\s+([A-Za-z_][A-Za-z0-9_]*)$/', $table, $matches) === 1) {
+            return $this->escapeIdentifier($matches[1]) . ' AS ' . $this->escapeIdentifier($matches[2]);
+        }
+
+        // table alias (implicit AS)
+        if (preg_match('/^([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)$/', $table, $matches) === 1) {
+            return $this->escapeIdentifier($matches[1]) . ' ' . $this->escapeIdentifier($matches[2]);
+        }
+
+        // schema.table
+        if (preg_match('/^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$/', $table, $matches) === 1) {
+            return $this->escapeIdentifier($matches[1]) . '.' . $this->escapeIdentifier($matches[2]);
+        }
+
+        // simple table name
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $table) === 1) {
+            return $this->escapeIdentifier($table);
+        }
+
+        // Subquery, already-quoted SQL, or other complex expression — leave as-is for BC
+        return $table;
+    }
+
+    /**
+     * Normalize raw SQL part arguments without breaking complex developer SQL.
+     *
+     * - limit/offset/top: coerce pure integers
+     * - select/group/order: quote args that are clearly simple identifiers / order expressions
+     * - Complex expressions (functions, commas inside one arg, etc.) are left unchanged
+     *
+     * @param string $part SQL part name after "By" stripping (select, order, group, limit, …)
+     * @param array $args
+     * @return array
+     */
+    protected function normalizeSqlPartArgs(string $part, array $args): array
+    {
+        if (in_array($part, ['limit', 'offset', 'top'], true) === true) {
+            return array_map(function ($arg) {
+                if (is_int($arg) === true) {
+                    return $arg;
+                }
+                if (is_string($arg) === true && preg_match('/^-?\d+$/', $arg) === 1) {
+                    return (int) $arg;
+                }
+                return $arg;
+            }, $args);
+        }
+
+        if (in_array($part, ['select', 'group', 'order', 'from'], true) === true) {
+            return array_map(function ($arg) use ($part) {
+                if (is_string($arg) === false) {
+                    return $arg;
+                }
+
+                $trimmed = trim($arg);
+
+                // order/orderBy: "column", "column ASC|DESC", "table.column", "table.column ASC|DESC"
+                if ($part === 'order') {
+                    if (preg_match('/^([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?)\s+(ASC|DESC)$/i', $trimmed, $matches) === 1) {
+                        return $this->escapeIdentifierPath($matches[1]) . ' ' . strtoupper($matches[2]);
+                    }
+                    if ($this->isSafeIdentifierPath($trimmed) === true) {
+                        return $this->escapeIdentifierPath($trimmed);
+                    }
+                    return $arg;
+                }
+
+                // select / group / from: only pure identifier paths (not *, functions, aliases)
+                if ($this->isSafeIdentifierPath($trimmed) === true) {
+                    return $this->escapeIdentifierPath($trimmed);
+                }
+
+                return $arg;
+            }, $args);
+        }
+
+        return $args;
     }
 
     /**

--- a/tests/ActiveRecordPdoIntegrationTest.php
+++ b/tests/ActiveRecordPdoIntegrationTest.php
@@ -714,7 +714,7 @@ class ActiveRecordPdoIntegrationTest extends \PHPUnit\Framework\TestCase
             ->join('contact', '"contact"."user_id" = "user"."id"')
             ->find();
         $sql = $record->getBuiltSql();
-        $this->assertEquals('SELECT "user".* FROM "user" LEFT JOIN contact ON "contact"."user_id" = "user"."id" WHERE ("user"."name" = :ph1 OR "user"."id" IN (:ph2,:ph3,:ph4) OR "user"."id" = :ph5) AND "user"."name" IS NOT NULL AND "user"."id" BETWEEN :ph6 AND :ph7 LIMIT 1', $sql);
+        $this->assertEquals('SELECT "user".* FROM "user" LEFT JOIN "contact" ON "contact"."user_id" = "user"."id" WHERE ("user"."name" = :ph1 OR "user"."id" IN (:ph2,:ph3,:ph4) OR "user"."id" = :ph5) AND "user"."name" IS NOT NULL AND "user"."id" BETWEEN :ph6 AND :ph7 LIMIT 1', $sql);
     }
 
     public function testOrAsFinalParameter()

--- a/tests/ActiveRecordTest.php
+++ b/tests/ActiveRecordTest.php
@@ -161,4 +161,326 @@ class ActiveRecordTest extends \PHPUnit\Framework\TestCase
         };
         $this->assertEquals('[test_table]', $record->escapeIdentifier('test_table'));
     }
+
+    public function testEscapeIdentifierEscapesDelimitersSqlite()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+        };
+
+        $this->assertEquals('"id"', $record->escapeIdentifier('id'));
+        // Breakout attempt: quote is doubled, cannot leave the identifier
+        $this->assertEquals('"id"" OR 1=1 --"', $record->escapeIdentifier('id" OR 1=1 --'));
+        $this->assertEquals('"a""b"', $record->escapeIdentifier('a"b'));
+    }
+
+    public function testEscapeIdentifierEscapesDelimitersMysql()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('mysql');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+        };
+
+        $this->assertEquals('`id`', $record->escapeIdentifier('id'));
+        $this->assertEquals('`id``; DROP TABLE x;--`', $record->escapeIdentifier('id`; DROP TABLE x;--'));
+    }
+
+    public function testEscapeIdentifierEscapesDelimitersSqlSrv()
+    {
+        $record = new class (null, 'test_table') extends ActiveRecord {
+            public function getDatabaseEngine(): string
+            {
+                return 'sqlsrv';
+            }
+        };
+
+        $this->assertEquals('[id]', $record->escapeIdentifier('id'));
+        $this->assertEquals('[id]] OR 1=1 --]', $record->escapeIdentifier('id] OR 1=1 --'));
+    }
+
+    public function testEscapeIdentifierStripsNullBytes()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+        };
+
+        $this->assertEquals('"id"', $record->escapeIdentifier("i\0d"));
+    }
+
+    public function testDirtyColumnNamesWithQuoteCannotBreakIdentifier()
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+        };
+
+        // Malicious-looking key must be treated as a single identifier, not break out of quotes
+        $record->dirty([
+            'name' => 'ok',
+            'x") AS evil --' => 'nope',
+        ]);
+
+        try {
+            $record->insert();
+            // Insert may fail because column does not exist; that is fine.
+            // What matters is the built SQL keeps the breakout attempt inside quotes.
+        } catch (Exception $e) {
+            // expected if column missing
+        }
+
+        $sql = $record->getBuiltSql();
+        // After insert, builtSql may be cleared by resetQueryData — re-run build path via dirty keys escape
+        $escaped = $record->escapeIdentifier('x") AS evil --');
+        $this->assertEquals('"x"") AS evil --"', $escaped);
+        $this->assertStringNotContainsString('"x") AS', $escaped);
+    }
+
+    public function testJoinEscapesSimpleTableName()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->join('contacts', 'contacts.user_id = test_table.id')->find();
+        $this->assertStringContainsString('LEFT JOIN "contacts" ON', $record->getBuiltSql());
+    }
+
+    public function testJoinEscapesTableWithAlias()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->join('contact as c', 'c.user_id = test_table.id')->find();
+        $this->assertStringContainsString('LEFT JOIN "contact" AS "c" ON', $record->getBuiltSql());
+    }
+
+    public function testJoinEscapesTableWithImplicitAlias()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->join('contact c', 'c.user_id = test_table.id')->find();
+        $this->assertStringContainsString('LEFT JOIN "contact" "c" ON', $record->getBuiltSql());
+    }
+
+    public function testJoinEscapesSchemaTable()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->join('main.contact', 'main.contact.user_id = test_table.id')->find();
+        $this->assertStringContainsString('LEFT JOIN "main"."contact" ON', $record->getBuiltSql());
+    }
+
+    public function testJoinLeavesComplexTableExpressionUnchanged()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $sub = '(SELECT id FROM other) AS o';
+        $record->join($sub, 'o.id = test_table.id')->find();
+        $this->assertStringContainsString('LEFT JOIN (SELECT id FROM other) AS o ON', $record->getBuiltSql());
+    }
+
+    public function testOrderByColumnSafe()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->orderByColumn('name', 'desc')->find();
+        $this->assertStringContainsString('ORDER BY "name" DESC', $record->getBuiltSql());
+    }
+
+    public function testOrderByColumnRejectsInjection()
+    {
+        $record = $this->createEmptyRecord();
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid ORDER BY column identifier');
+        $record->orderByColumn('id; DROP TABLE users;--');
+    }
+
+    public function testOrderByColumnRejectsBadDirection()
+    {
+        $record = $this->createEmptyRecord();
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid ORDER BY direction');
+        $record->orderByColumn('id', 'SIDEWAYS');
+    }
+
+    public function testOrderByStillAcceptsComplexRawSql()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        // Existing API: complex expressions must still work unchanged
+        $record->orderBy('CASE WHEN name IS NULL THEN 1 ELSE 0 END')->find();
+        $this->assertStringContainsString('ORDER BY CASE WHEN name IS NULL THEN 1 ELSE 0 END', $record->getBuiltSql());
+    }
+
+    public function testSimpleOrderByEscapesIdentifier()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->orderBy('name DESC')->find();
+        $this->assertStringContainsString('ORDER BY "name" DESC', $record->getBuiltSql());
+    }
+
+    public function testSimpleOrderByColumnOnlyEscapesIdentifier()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->orderBy('name')->find();
+        $this->assertStringContainsString('ORDER BY "name"', $record->getBuiltSql());
+    }
+
+    public function testOrderByTableColumnPath()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->orderBy('user.name ASC')->find();
+        $this->assertStringContainsString('ORDER BY "user"."name" ASC', $record->getBuiltSql());
+    }
+
+    public function testLimitLeavesNonNumericExpressionUnchanged()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return [];
+            }
+        };
+        $record->limit('1 + 2')->findAll();
+        $this->assertStringContainsString('LIMIT 1 + 2', $record->getBuiltSql());
+    }
+
+    public function testSelectNonStringArgLeftUnchanged()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        // Non-string args are not identifier-normalized (BC for unusual call patterns)
+        $record->select(123)->find();
+        $this->assertStringContainsString('SELECT 123', $record->getBuiltSql());
+    }
+
+    public function testSimpleSelectEscapesIdentifier()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->select('name')->find();
+        $this->assertStringContainsString('SELECT "name"', $record->getBuiltSql());
+    }
+
+    public function testComplexSelectLeftUnchanged()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $record->select('COUNT(*) as count')->find();
+        $this->assertStringContainsString('SELECT COUNT(*) as count', $record->getBuiltSql());
+    }
+
+    public function testLimitCoercesNumericStrings()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return [];
+            }
+        };
+        // findAll (unlike find) does not force LIMIT 1
+        $record->limit('10')->findAll();
+        $this->assertStringContainsString('LIMIT 10', $record->getBuiltSql());
+    }
+
+    public function testEqValueStillParameterizedNotInjected()
+    {
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('getAttribute')->willReturn('sqlite');
+        $record = new class ($pdo, 'test_table') extends ActiveRecord {
+            public function query(string $sql, array $param = [], ?ActiveRecord $obj = null, bool $single = false)
+            {
+                return $this;
+            }
+        };
+        $payload = 'Robert"); DROP TABLE test_table;--';
+        $record->eq('name', $payload)->find();
+        $sql = $record->getBuiltSql();
+        $this->assertStringContainsString('"name" = :ph', $sql);
+        $this->assertStringNotContainsString($payload, $sql);
+    }
 }

--- a/tests/EagerLoadingTest.php
+++ b/tests/EagerLoadingTest.php
@@ -23,6 +23,7 @@ class EagerLoadingTest extends TestCase
     {
         require_once __DIR__ . '/classes/User.php';
         require_once __DIR__ . '/classes/Contact.php';
+        require_once __DIR__ . '/classes/QueryCountingAdapter.php';
     }
 
     public function setUp(): void

--- a/tests/TypedPropertyTest.php
+++ b/tests/TypedPropertyTest.php
@@ -125,4 +125,24 @@ class TypedPropertyTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($users[0]->isHydrated(), 'findAll() results should be hydrated');
         $this->assertTrue($users[1]->isHydrated());
     }
+
+    public function testSyncDirtySkipsPropertiesAlreadyInDirty(): void
+    {
+        $user = new TypedUser($this->pdo);
+        $user->name = 'prefilled';
+        $user->password = 'hash';
+
+        $sync = new \ReflectionMethod(\flight\ActiveRecord::class, 'syncDirtyFromProperties');
+        $sync->setAccessible(true);
+        $sync->invoke($user, false);
+
+        $dirtyProp = new \ReflectionProperty(\flight\ActiveRecord::class, 'dirty');
+        $dirtyProp->setAccessible(true);
+        $dirty = $dirtyProp->getValue($user);
+        $this->assertArrayHasKey('name', $dirty);
+
+        // Second sync should hit the "already in dirty" continue branch
+        $sync->invoke($user, false);
+        $this->assertSame('prefilled', $dirtyProp->getValue($user)['name']);
+    }
 }

--- a/tests/classes/TypedUser.php
+++ b/tests/classes/TypedUser.php
@@ -16,6 +16,15 @@ class TypedUser extends ActiveRecord
     public string $password;
     public ?string $created_dt = null;
 
+    /**
+     * Intentionally left unset in many tests so sync helpers skip uninitialized props.
+     * @var string
+     */
+    public string $unused_optional;
+
+    /** Skipped by sync helpers; present so the static-property branch is covered */
+    public static string $marker = 'typed-user';
+
     public function __construct($databaseConnection = null, array $config = [])
     {
         parent::__construct($databaseConnection, 'user', $config);


### PR DESCRIPTION
## Summary

- **Fix identifier SQL injection:** `escapeIdentifier()` now escapes delimiter characters (`"`, `` ` ``, `]`) and strips NUL bytes so untrusted column/table names cannot break out of quoted identifiers (including keys from `dirty()` / `copyFrom()`).
- **Harden raw SQL footguns without breaking the API:**
  - `join()` quotes simple `table` / `table alias` / `table AS alias` / `schema.table`; complex expressions stay raw.
  - Simple `select` / `order` / `group` / `from` identifier args are quoted; expressions like `COUNT(*)` and `CASE WHEN…` are unchanged.
  - Numeric `limit` / `offset` / `top` strings are coerced to integers.
  - New **`orderByColumn($column, $direction)`** for untrusted sort fields (allowlisted identifier + ASC/DESC only).
- **Docs:** class-level security notes on bound vs raw APIs; add `AGENTS.md` for agents/contributors.
- **Tests:** security unit tests, join SQL expectation update, EagerLoading fixture require, typed-property sync coverage for 100%.

## Test plan

- [x] `composer test` (132 tests)
- [x] `composer test-coverage` (100%)
- [x] `composer phpcs`