### PR TITLE
findAll() reuses the same object for every fetched row

### DIFF
--- a/src/ActiveRecord.php
+++ b/src/ActiveRecord.php
@@ -496,7 +496,8 @@ abstract class ActiveRecord extends Base implements JsonSerializable
                 continue;
             }
 
-            if ($prop->isInitialized($this) && !array_key_exists($name, $this->data)) {
+            // Overwrite so findAll() rows after the first don't inherit the prior row's data.
+            if ($prop->isInitialized($this)) {
                 $this->data[$name] = $this->{$name};
             }
         }

--- a/tests/TypedPropertyTest.php
+++ b/tests/TypedPropertyTest.php
@@ -126,6 +126,26 @@ class TypedPropertyTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($users[1]->isHydrated());
     }
 
+    public function testFindAllRowsDoNotInheritPriorRowData(): void
+    {
+        $this->pdo->exec("INSERT INTO user (name, password) VALUES ('alice', 'hash1')");
+        $this->pdo->exec("INSERT INTO user (name, password) VALUES ('bob', 'hash2')");
+
+        $users = (new TypedUser($this->pdo))->findAll();
+
+        $this->assertSame('bob', $users[1]->name, 'typed property should hold row 2 value');
+        $this->assertSame(
+            'bob',
+            $users[1]->getData()['name'] ?? null,
+            'getData() should hold row 2 value, not the prior row\'s'
+        );
+        $this->assertSame(
+            'hash2',
+            $users[1]->getData()['password'] ?? null,
+            'getData() should hold row 2 value, not the prior row\'s'
+        );
+    }
+
     public function testSyncDirtySkipsPropertiesAlreadyInDirty(): void
     {
         $user = new TypedUser($this->pdo);


### PR DESCRIPTION
Yep, it's me again...

## The Bug 

`query()`'s findAll loop (src/ActiveRecord.php:974) reuses the same `$obj` for every row via `PDO::FETCH_INTO`, which sets typed public properties directly and bypasses `__set()`. `syncDeclaredProperties()` exists to copy those typed props into `$data`. The original `!array_key_exists(...)` guard skipped that copy for any key already present in `$data`  (i.e., every key set while fetching the previous row) 

**Result:** rows 2+ carried row 1's values in `getData()` while their typed properties held the fresh row's values, so `getData()`, `isHydrated()`, and update baselines were silently stale.

**Why always-overwrite is safe.** `query()` calls `reset(false)` (src/ActiveRecord.php:961) before any fetch, which wipes `$data`. So the only way keys can pre-exist in `$data` when sync runs is object reuse *within* the findAll loop. There was no legitimate value the guard protected I could find. 

Additional checks:
- Single `find()` is unaffected (object is reset before each fetch)
- Columns absent from the result set behave identically under both versions
- `ReflectionProperty::isInitialized()` is PHP 7.4-safe

## Empirical verification
- Repro script against **original** code: **FAIL** : 2nd row's `getData()` returned `'alice'/'hash1'` instead of `'bob'/'hash2'`
- Repro script against **new** code: **PASS**
- `composer test`: 226 tests, all green

## The change
```php
// Before
if ($prop->isInitialized($this) && !array_key_exists($name, $this->data)) {
// After
if ($prop->isInitialized($this)) {
```

## Test added

`testFindAllRowsDoNotInheritPriorRowData` (tests/TypedPropertyTest.php:130) : Inserts two distinct rows, runs `findAll()`, and asserts row 2's typed property, `getData()['name']`, and `getData()['password']` all hold row 2's values.

- vs original code: FAIL : `'alice'` ≠ `'bob'`
- vs new code: PASS
- Full suite: OK :+1:  (227 tests, 459 assertions), phpcs clean :+1: 


Cheers